### PR TITLE
refactor: navigation이 필요없는 페이지 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import '../styles/globals.css';
 import { Providers } from './providers';
 import { gmarketSans, OwnglyphPDH } from '@/styles/font';
-import Navigation from '@/components/common/Navigation';
+import { NavigationWrapper } from '@/components/common/Navigation/NavigationWrapper';
 
 export const metadata: Metadata = {
   title: '붕마카세',
@@ -21,7 +21,7 @@ export default function RootLayout({
       >
         <Providers>
           <section className="w-full h-screen xs:w-[375px]">{children}</section>
-          <Navigation />
+          <NavigationWrapper />
         </Providers>
       </body>
     </html>

--- a/src/components/common/Navigation/NavigationWrapper.tsx
+++ b/src/components/common/Navigation/NavigationWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import Navigation from '@/components/common/Navigation';
-import { shouldShowNavigation } from '@/lib/utils';
+import { shouldShowNavigation } from '@/lib/router';
 
 export function NavigationWrapper() {
   const pathname = usePathname();

--- a/src/components/common/Navigation/NavigationWrapper.tsx
+++ b/src/components/common/Navigation/NavigationWrapper.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Navigation from '@/components/common/Navigation';
+import { shouldShowNavigation } from '@/lib/utils';
+
+export function NavigationWrapper() {
+  const pathname = usePathname();
+
+  if (!shouldShowNavigation(pathname)) {
+    return null;
+  }
+
+  return <Navigation />;
+}

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,8 @@
+export const shouldShowNavigation = (pathname: string): boolean => {
+  // Navigation을 숨길 경로 패턴들
+  const hidePatterns = ['/onboarding', '/login', '/user/auth'];
+
+  return !hidePatterns.some(
+    (pattern) => pathname === pattern || pathname.startsWith(`${pattern}/`),
+  );
+};


### PR DESCRIPTION
로그인 화면 작업하면서 /login 페이지에 bottom navigation이 없어야 하는걸 뒤늦게 알게 되면서, 따로 브랜치따서 작업했습니다.
앞으로 bottom navigation이 필요없는 페이지는, router.ts에 경로 추가해주시면 될 것 같아요.