### PR TITLE
feat: login - ProfileForm UI 제작, file upload 기능 hooks

### DIFF
--- a/src/app/signup/profile/page.tsx
+++ b/src/app/signup/profile/page.tsx
@@ -1,0 +1,5 @@
+import { ProfileForm } from '@/components/ProfileForm';
+
+export default function SignupProfilePage() {
+  return <ProfileForm />;
+}

--- a/src/components/ProfileForm/index.tsx
+++ b/src/components/ProfileForm/index.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import Image from 'next/image';
+import BackButton from '../common/BackButton';
+import Logo from '../common/Logo';
+import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { Loader2 } from 'lucide-react';
+
+import { BaseInput } from '../common/BaseInput';
+import { Info } from 'lucide-react';
+import { Button } from '../ui/button';
+import { z } from 'zod';
+import { useRef, useState } from 'react';
+import { useImageUpload } from '@/hooks/useImageUpload';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+const nicknameSchema = z
+  .string()
+  .min(1, '닉네임을 입력해주세요')
+  .max(12, '닉네임은 12자 이내로 입력해주세요')
+  .regex(/^[가-힣a-z]+$/, '닉네임은 한글과 영문 소문자만 입력 가능합니다');
+
+export function ProfileForm() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [profileImage, setProfileImage] = useState('');
+  const { uploadImage, isUploading } = useImageUpload();
+  const [isDuplicate, setIsDuplicate] = useState(false);
+
+  const {
+    register,
+    formState: { errors, dirtyFields },
+    watch,
+    handleSubmit,
+    trigger,
+  } = useForm({
+    resolver: zodResolver(nicknameSchema),
+    mode: 'onChange',
+  });
+
+  const watchedNickname = watch('nickname');
+
+  const getNicknameCorrect = () => {
+    if (!dirtyFields.nickname || errors.nickname) return '';
+    if (nicknameSchema.safeParse(watchedNickname).success) {
+      return '사용 가능한 닉네임입니다';
+    }
+    return '';
+  };
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const imageUrl = await uploadImage(file);
+      setProfileImage(imageUrl as string);
+    }
+  };
+
+  const handleDuplicateCheck = async () => {
+    const isValid = await trigger('nickname');
+    if (!isValid) return;
+
+    // TODO: 중복 체크 API 호출
+    setIsDuplicate(true);
+  };
+
+  const onSubmit = handleSubmit(async (data) => {
+    const isValid = await trigger('nickname');
+    if (!isValid) return;
+
+    console.log('Form submitted:', {
+      ...data,
+      profileImage,
+    });
+  });
+
+  return (
+    <motion.section
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="bg-yellow-gradient h-screen px-6 py-8 flex flex-col items-center"
+    >
+      <div className="w-full">
+        <header className="flex flex-col gap-1">
+          <div>
+            <BackButton />
+          </div>
+          <div className="flex flex-col gap-2">
+            <h1 className="text-xl text-[#181818]">
+              프로필을
+              <br />
+              작성해주세요 :)
+            </h1>
+          </div>
+        </header>
+
+        <form
+          className="h-full flex flex-col items-center mt-24"
+          onSubmit={onSubmit}
+        >
+          <motion.div
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className={cn(
+              'w-[157px] h-[157px] relative rounded-full bg-[#F6EEDF] flex justify-center items-center cursor-pointer mb-6 border border-[#FFD997]',
+              isUploading && 'opacity-50',
+            )}
+            onClick={handleImageClick}
+          >
+            {profileImage ? (
+              <Image
+                src={profileImage}
+                alt="프로필 이미지"
+                fill
+                className="rounded-full object-cover"
+              />
+            ) : (
+              <Logo size="medium" />
+            )}
+            <motion.div
+              className="rounded-full w-[50px] h-[50px] flex items-center justify-center bg-primary absolute bottom-0 right-0"
+              whileHover={{ scale: 1.1 }}
+            >
+              {isUploading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Image
+                  src="/images/svg/photo.svg"
+                  alt="사진"
+                  width={28}
+                  height={28}
+                />
+              )}
+            </motion.div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleImageChange}
+              disabled={isUploading}
+            />
+          </motion.div>
+
+          <div className="w-full flex items-center gap-2">
+            <div className="flex-1">
+              <BaseInput
+                id="nickname"
+                label="닉네임"
+                placeholder="닉네임을 입력해주세요"
+                correct={getNicknameCorrect()}
+                {...register('nickname')}
+                helperText={
+                  <div className="absolute flex items-center gap-1">
+                    <Info className="w-4 h-4" />
+                    <span className="text-xs">
+                      닉네임은 한글과 영문 소문자 12자 이내로 입력해주세요.
+                    </span>
+                  </div>
+                }
+              />
+            </div>
+            <Button
+              type="button"
+              onClick={handleDuplicateCheck}
+              className="w-[70px] h-[50px] self-start mt-8 text-xs"
+            >
+              중복 확인
+            </Button>
+          </div>
+
+          <Button
+            type="submit"
+            className="mt-auto w-full"
+            disabled={!isDuplicate}
+          >
+            완료
+          </Button>
+        </form>
+      </div>
+    </motion.section>
+  );
+}

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+
+export const useImageUpload = () => {
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadImage = async (file: File) => {
+    try {
+      setIsUploading(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsDataURL(file);
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return { uploadImage, isUploading };
+};

--- a/src/store/useSignUpStore.ts
+++ b/src/store/useSignUpStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { FormData } from '@/components/LoginForm';
+
+interface SignUpState {
+  loginData: Partial<FormData>;
+  setLoginData: (data: FormData) => void;
+  reset: () => void;
+}
+
+export const useSignUpStore = create<SignUpState>((set) => ({
+  loginData: {},
+  setLoginData: (data) => set({ loginData: data }),
+  reset: () => set({ loginData: {} }),
+}));


### PR DESCRIPTION
<img width="396" alt="스크린샷 2025-02-08 오후 5 33 14" src="https://github.com/user-attachments/assets/4b96e96b-4e16-4133-98f8-eaba47b824ed" />

파일 업로드 하는 함수 hooks 폴더에 있으니 필요하시면 가져다가 쓰시면 될 것 같아요.
피그마 플로우상 이메일 회원가입 데이터(이메일, 비밀번호)를 받은 이후에 프로필관련 정보를 받아야 회원가입이 완료되는 구조입니다.
LoginForm과 ProfileForm 간의 라우터도 필요하다 생각하였고(뒤로가기 기능), ProfileForm에서 email의 LoginForm 데이터가 필요하기 떄문에 useSignupStore에서 상태를 공유하도록 했습니다.

근데 지금, 이메일 회원가입 플로우는 있는데 이메일 로그인 화면은 따로 없는 것 같아 PM, 디자이너분에게 확인 요청드렸어요.