### PR TITLE
test: 로고 옵션값추가

### DIFF
--- a/src/components/common/Logo/Logo.stories.tsx
+++ b/src/components/common/Logo/Logo.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['xSmall', 'small', 'medium', 'large'],
+      options: ['xSmall', 'small', 'xMedium', 'medium', 'large'],
       description: 'Logo size variant',
       table: {
         defaultValue: { summary: 'medium' },
@@ -43,6 +43,10 @@ export const AllSizes: Story = {
       <div className="flex items-center gap-2">
         <Logo size="small" />
         <span className="text-sm text-gray-500">small (49x34)</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Logo size="xMedium" />
+        <span className="text-sm text-gray-500">xMedium (78x55)</span>
       </div>
       <div className="flex items-center gap-2">
         <Logo size="medium" />


### PR DESCRIPTION
코드리뷰에 남겨주셨던 공통붕어빵 작업을하면서 로고사이즈 `xMedium` 78x55 추가했었습니다!
일전에 성진님이 작업해놓으셨던 스토리북 로고 부분에 추가적으로 옵션값 넣어놨습니다