### PR TITLE
Feature/labeled info field

### DIFF
--- a/src/components/common/LabeledInfoField/LabeledInfoField.stories.tsx
+++ b/src/components/common/LabeledInfoField/LabeledInfoField.stories.tsx
@@ -1,14 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { LabeledInfoField } from './index';
+import { useState } from 'react';
 
 const meta: Meta<typeof LabeledInfoField> = {
-  title: 'components/common/LabeledInfoField',
+  title: 'Components/Common/LabeledInfoField',
   component: LabeledInfoField,
   parameters: {
     layout: 'centered',
     docs: {
       description: {
-        component: '라벨과 값을 함께 표시하는 정보 필드 컴포넌트입니다.',
+        component:
+          '라벨과 값을 표시하는 필드 컴포넌트입니다. 편집 가능한 입력 모드와 읽기 전용 모드를 지원합니다.',
       },
     },
   },
@@ -21,6 +23,18 @@ const meta: Meta<typeof LabeledInfoField> = {
     value: {
       description: '표시할 값',
       control: 'text',
+    },
+    isEditable: {
+      description: '편집 가능 여부',
+      control: 'boolean',
+    },
+    placeholder: {
+      description: '입력 필드의 플레이스홀더',
+      control: 'text',
+    },
+    disabled: {
+      description: '비활성화 여부',
+      control: 'boolean',
     },
   },
   decorators: [
@@ -35,37 +49,85 @@ const meta: Meta<typeof LabeledInfoField> = {
 export default meta;
 type Story = StoryObj<typeof LabeledInfoField>;
 
-// 기본 스토리
-export const Default: Story = {
+// 읽기 전용 모드
+export const ReadOnly: Story = {
   args: {
     label: '영업시간',
     value: '09:00 ~ 18:00',
+    isEditable: false,
   },
 };
 
-// 긴 텍스트 스토리
+// 편집 가능 모드
+export const Editable: Story = {
+  render: function Render() {
+    const [value, setValue] = useState('09:00 ~ 18:00');
+
+    return (
+      <LabeledInfoField
+        label="영업시간"
+        value={value}
+        isEditable={true}
+        onChange={setValue}
+        placeholder="영업시간을 입력하세요"
+      />
+    );
+  },
+};
+
+// 비활성화 상태
+export const Disabled: Story = {
+  args: {
+    label: '영업시간',
+    value: '09:00 ~ 18:00',
+    isEditable: true,
+    disabled: true,
+  },
+};
+
+// 긴 텍스트
 export const LongText: Story = {
   args: {
-    label: '매장 위치',
-    value: '서울특별시 강남구 테헤란로 123길 45, 7층 701호',
+    label: '주소',
+    value: '서울특별시 강남구 테헤란로 123길 45, 7층 701호 (매우 긴 주소)',
+    isEditable: false,
   },
 };
 
-// 짧은 텍스트 스토리
-export const ShortText: Story = {
-  args: {
-    label: '가격',
-    value: '1,000원',
-  },
-};
+// 다양한 상태 조합
+export const Various: Story = {
+  render: function Render() {
+    const [value1, setValue1] = useState('09:00 ~ 18:00');
+    const [value2, setValue2] = useState('');
 
-export const Multiple: Story = {
-  render: () => (
-    <div className="space-y-2">
-      <LabeledInfoField label="영업시간" value="09:00 ~ 18:00" />
-      <LabeledInfoField label="전화번호" value="02-1234-5678" />
-      <LabeledInfoField label="주소" value="서울시 강남구" />
-      <LabeledInfoField label="메뉴" value="붕어빵 (팥/슈크림)" />
-    </div>
-  ),
+    return (
+      <div className="space-y-2">
+        <LabeledInfoField
+          label="읽기 전용"
+          value="이 값은 수정할 수 없습니다"
+          isEditable={false}
+        />
+        <LabeledInfoField
+          label="편집 가능"
+          value={value1}
+          isEditable={true}
+          onChange={setValue1}
+          placeholder="시간을 입력하세요"
+        />
+        <LabeledInfoField
+          label="비활성화"
+          value="비활성화된 필드"
+          isEditable={true}
+          disabled={true}
+        />
+        <LabeledInfoField
+          label="빈 값"
+          value={value2}
+          isEditable={true}
+          onChange={setValue2}
+          placeholder="값을 입력하세요"
+        />
+      </div>
+    );
+  },
 };

--- a/src/components/common/LabeledInfoField/LabeledInfoField.stories.tsx
+++ b/src/components/common/LabeledInfoField/LabeledInfoField.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LabeledInfoField } from './index';
+
+const meta: Meta<typeof LabeledInfoField> = {
+  title: 'components/common/LabeledInfoField',
+  component: LabeledInfoField,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '라벨과 값을 함께 표시하는 정보 필드 컴포넌트입니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      description: '필드의 라벨',
+      control: 'text',
+    },
+    value: {
+      description: '표시할 값',
+      control: 'text',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LabeledInfoField>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    label: '영업시간',
+    value: '09:00 ~ 18:00',
+  },
+};
+
+// 긴 텍스트 스토리
+export const LongText: Story = {
+  args: {
+    label: '매장 위치',
+    value: '서울특별시 강남구 테헤란로 123길 45, 7층 701호',
+  },
+};
+
+// 짧은 텍스트 스토리
+export const ShortText: Story = {
+  args: {
+    label: '가격',
+    value: '1,000원',
+  },
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <LabeledInfoField label="영업시간" value="09:00 ~ 18:00" />
+      <LabeledInfoField label="전화번호" value="02-1234-5678" />
+      <LabeledInfoField label="주소" value="서울시 강남구" />
+      <LabeledInfoField label="메뉴" value="붕어빵 (팥/슈크림)" />
+    </div>
+  ),
+};

--- a/src/components/common/LabeledInfoField/index.tsx
+++ b/src/components/common/LabeledInfoField/index.tsx
@@ -1,13 +1,38 @@
+import { Input } from '@/components/ui/input';
+
 interface LabeledInfoFieldProps {
   label: string;
   value: string;
+  isEditable?: boolean;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
 }
 
-export function LabeledInfoField({ label, value }: LabeledInfoFieldProps) {
+export function LabeledInfoField({
+  label,
+  value,
+  isEditable = false,
+  onChange,
+  placeholder,
+  disabled = false,
+}: LabeledInfoFieldProps) {
   return (
-    <div className="h-[70px] mb-2 flex items-center justify-between px-8 border border-[#d6d6d6] rounded-lg cursor-pointer">
-      <span>{label}</span>
-      <span className="max-w-[250px] font-light truncate">{value}</span>
+    <div className="h-[70px] mb-2 flex items-center justify-between px-8 border border-[#d6d6d6] rounded-lg">
+      <span className="shrink-0 mr-4">{label}</span>
+      {isEditable ? (
+        <Input
+          value={value}
+          onChange={(e) => onChange?.(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="max-w-[250px] font-light text-right"
+        />
+      ) : (
+        <span className="max-w-[250px] font-light truncate text-right">
+          {value}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/components/common/LabeledInfoField/index.tsx
+++ b/src/components/common/LabeledInfoField/index.tsx
@@ -1,0 +1,13 @@
+interface LabeledInfoFieldProps {
+  label: string;
+  value: string;
+}
+
+export function LabeledInfoField({ label, value }: LabeledInfoFieldProps) {
+  return (
+    <div className="h-[70px] mb-2 flex items-center justify-between px-8 border border-[#d6d6d6] rounded-lg cursor-pointer">
+      <span>{label}</span>
+      <span className="max-w-[250px] font-light truncate">{value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
<img width="103" alt="스크린샷 2025-02-10 오후 2 21 54" src="https://github.com/user-attachments/assets/8560862d-07c9-4e5a-ba52-a4b375238a37" />
<img width="175" alt="스크린샷 2025-02-10 오후 2 22 02" src="https://github.com/user-attachments/assets/d27d58c1-65c4-441d-83b8-9f81defa9d7f" />

위 이미지들에서 사용되어지는 각각의 div 컴포넌트고, mvp는 아니지만 붕 레벨 같은 곳에서도 많이쓰여 분리했습니다.
readonly면 span, editable 이면 Input 태그로 수정할 수 있게 했습니다.
네이밍을 많이 고민했는데, 적절한진 모르겠네요..