### PR TITLE
refactor: email login signup form refactor, add email login form

### DIFF
--- a/src/api/signup.ts
+++ b/src/api/signup.ts
@@ -1,4 +1,4 @@
-import { FormData } from '@/components/LoginForm';
+import { FormData } from '@/components/SignupForm';
 
 interface SignUpResponse {
   success: boolean;

--- a/src/app/login/email/page.tsx
+++ b/src/app/login/email/page.tsx
@@ -1,7 +1,7 @@
 import BackButton from '@/components/common/BackButton';
-import { SignupForm } from '@/components/SignupForm';
+import { LoginForm } from '@/components/LoginForm';
 
-export default function SignupEmailPage() {
+export default function LoginEmailPage() {
   return (
     <section className="h-screen px-5 py-8">
       <header className="flex flex-col">
@@ -10,17 +10,17 @@ export default function SignupEmailPage() {
         </div>
         <div className="flex flex-col gap-2">
           <h1 className="text-xl font-semibold text-[#181818]">
-            로그인 시 필요한
+            로그인 정보를
             <br />
-            정보를 입력해주세요
+            입력해주세요
           </h1>
           <span className="text-sm text-muted-foreground">
-            회원가입을 위해 필요합니다.
+            로그인을 위해 필요합니다.
           </span>
         </div>
       </header>
 
-      <SignupForm />
+      <LoginForm />
     </section>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -56,7 +56,7 @@ export default function LoginPage() {
               className="absolute left-4"
               alt="kakao"
             />
-            <Link href="/signup/email">
+            <Link href="/login/email">
               <span className="flex-1 text-center">이메일로 시작하기</span>
             </Link>
           </Button>

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -1,44 +1,35 @@
 'use client';
 
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { BaseInput } from '@/components/common/BaseInput';
-import { Button } from '@/components/ui/button';
-import { Info } from 'lucide-react';
-import * as z from 'zod';
-import { Eye, EyeOff } from 'lucide-react';
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useSignUpStore } from '@/store/useSignUpStore';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { BaseInput } from '../common/BaseInput';
+import { Button } from '../ui/button';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
 
-const formSchema = z
-  .object({
-    email: z
-      .string()
-      .min(1, '이메일을 입력해주세요')
-      .email('올바른 이메일 형식이 아닙니다'),
-    password: z
-      .string()
-      .min(1, '비밀번호를 입력해주세요')
-      .min(8, '비밀번호는 8자 이상이어야 합니다')
-      .regex(
-        /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
-        '비밀번호는 영문+숫자 조합으로 8자 이상 입력해주세요.',
-      ),
-    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요'),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: '비밀번호가 일치하지 않습니다',
-    path: ['confirmPassword'],
-  });
+const formSchema = z.object({
+  email: z
+    .string()
+    .min(1, '이메일을 입력해주세요')
+    .email('올바른 이메일 형식이 아닙니다'),
+  password: z
+    .string()
+    .min(1, '비밀번호를 입력해주세요')
+    .min(8, '비밀번호는 8자 이상이어야 합니다')
+    .regex(
+      /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
+      '비밀번호는 영문+숫자 조합으로 8자 이상 입력해주세요.',
+    ),
+});
 
 export type FormData = z.infer<typeof formSchema>;
 
 export function LoginForm() {
-  const { setLoginData } = useSignUpStore();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const {
     register,
@@ -52,16 +43,6 @@ export function LoginForm() {
 
   const watchedPassword = watch('password');
   const watchedEmail = watch('email');
-  const watchedConfirmPassword = watch('confirmPassword');
-
-  // 각 필드의 유효성 상태 확인
-  const getEmailCorrect = () => {
-    if (!dirtyFields.email || errors.email) return '';
-    if (z.string().email().safeParse(watchedEmail).success) {
-      return '사용 가능한 이메일입니다';
-    }
-    return '';
-  };
 
   const getPasswordCorrect = () => {
     if (!dirtyFields.password || errors.password) return '';
@@ -77,114 +58,68 @@ export function LoginForm() {
     return '';
   };
 
-  const getConfirmPasswordCorrect = () => {
-    if (!dirtyFields.confirmPassword || errors.confirmPassword) return '';
-    if (watchedPassword === watchedConfirmPassword && watchedConfirmPassword) {
-      return '비밀번호가 일치합니다';
+  const getEmailCorrect = () => {
+    if (!dirtyFields.email || errors.email) return '';
+    if (z.string().email().safeParse(watchedEmail).success) {
+      return '사용 가능한 이메일입니다';
     }
     return '';
   };
 
-  // 모든 필드가 입력되었는지 확인
-  const watchedValues = watch(['email', 'password', 'confirmPassword']);
-  const isAllFieldsFilled = watchedValues.every((value) => value);
-
-  // 버튼 활성화 조건: 모든 필드가 입력되고, 에러가 없으며, 폼이 유효한 상태
-  const isButtonEnabled =
-    isAllFieldsFilled && isValid && Object.keys(errors).length === 0;
-
-  const onSubmit = handleSubmit((data) => {
-    setLoginData(data);
-    router.push('/signup/profile');
-  });
+  const handleLogin = (data: FormData) => {
+    // TODO: 로그인 API 호출
+    console.log(data);
+    router.push('/');
+  };
 
   return (
-    <form className="flex flex-col gap-6 mt-8" onSubmit={onSubmit}>
-      <BaseInput
-        id="email"
-        type="email"
-        label="이메일"
-        placeholder="이메일을 입력해주세요"
-        error={errors.email?.message}
-        correct={getEmailCorrect()}
-        {...register('email')}
-        helperText={
-          <div className="flex items-center gap-1">
-            <Info className="w-4 h-4" />
-            <span className="text-xs text-muted-foreground">
-              이메일은 추후 변경이 불가합니다.
-            </span>
-          </div>
-        }
-      />
+    <form
+      className="flex flex-col h-[calc(100vh-200px)] mt-8 justify-between"
+      onSubmit={handleSubmit(handleLogin)}
+    >
+      <div className="w-full flex flex-col gap-2">
+        <BaseInput
+          id="email"
+          type="email"
+          label="이메일"
+          placeholder="이메일을 입력해주세요"
+          error={errors.email?.message}
+          correct={getEmailCorrect()}
+          {...register('email')}
+        />
+        <BaseInput
+          id="password"
+          type={showPassword ? 'text' : 'password'}
+          label="비밀번호"
+          placeholder="비밀번호를 입력해주세요"
+          error={errors.password?.message}
+          correct={getPasswordCorrect()}
+          {...register('password')}
+          endIcon={
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="focus:outline-none"
+              tabIndex={-1}
+            >
+              {showPassword ? (
+                <Eye className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <EyeOff className="h-4 w-4 text-muted-foreground" />
+              )}
+            </button>
+          }
+        />
+      </div>
 
-      <BaseInput
-        id="password"
-        type={showPassword ? 'text' : 'password'}
-        label="비밀번호"
-        placeholder="비밀번호를 입력해주세요"
-        error={errors.password?.message}
-        correct={getPasswordCorrect()}
-        {...register('password')}
-        endIcon={
-          <button
-            type="button"
-            onClick={() => setShowPassword(!showPassword)}
-            className="focus:outline-none"
-            tabIndex={-1}
-          >
-            {showPassword ? (
-              <EyeOff className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <Eye className="h-4 w-4 text-muted-foreground" />
-            )}
-          </button>
-        }
-        helperText={
-          <div className="flex items-center gap-1">
-            <Info className="w-4 h-4" />
-            <span className="text-xs text-muted-foreground">
-              비밀번호는 영문+숫자 조합으로 8자 이상 입력해주세요.
-            </span>
-          </div>
-        }
-      />
-
-      <BaseInput
-        id="confirmPassword"
-        type={showConfirmPassword ? 'text' : 'password'}
-        label="비밀번호 확인"
-        placeholder="비밀번호를 다시 입력해주세요"
-        error={errors.confirmPassword?.message}
-        correct={getConfirmPasswordCorrect()}
-        {...register('confirmPassword')}
-        endIcon={
-          <button
-            type="button"
-            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-            className="focus:outline-none"
-            tabIndex={-1}
-          >
-            {showConfirmPassword ? (
-              <EyeOff className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <Eye className="h-4 w-4 text-muted-foreground" />
-            )}
-          </button>
-        }
-        helperText={
-          <div className="flex items-center gap-1">
-            <Info className="w-4 h-4" />
-            <span className="text-xs text-muted-foreground">
-              비밀번호를 다시 한번 입력해주세요.
-            </span>
-          </div>
-        }
-      />
-
-      <Button type="submit" className="mt-20" disabled={!isButtonEnabled}>
-        이동
-      </Button>
+      <div className="w-full flex flex-col gap-2 items-center mt-auto pb-8">
+        <Link href="/signup/email" className="underline text-sm">
+          회원가입하기
+        </Link>
+        <Button type="submit" className="w-full" disabled={!isValid}>
+          완료
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/components/SignupForm/index.tsx
+++ b/src/components/SignupForm/index.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { BaseInput } from '@/components/common/BaseInput';
+import { Button } from '@/components/ui/button';
+import { Info } from 'lucide-react';
+import * as z from 'zod';
+import { Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSignUpStore } from '@/store/useSignUpStore';
+
+const formSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, '이메일을 입력해주세요')
+      .email('올바른 이메일 형식이 아닙니다'),
+    password: z
+      .string()
+      .min(1, '비밀번호를 입력해주세요')
+      .min(8, '비밀번호는 8자 이상이어야 합니다')
+      .regex(
+        /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
+        '비밀번호는 영문+숫자 조합으로 8자 이상 입력해주세요.',
+      ),
+    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['confirmPassword'],
+  });
+
+export type FormData = z.infer<typeof formSchema>;
+
+export function SignupForm() {
+  const { setLoginData } = useSignUpStore();
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isDuplicate, setIsDuplicate] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, dirtyFields, isValid },
+    watch,
+    trigger,
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+  });
+
+  const watchedPassword = watch('password');
+  const watchedEmail = watch('email');
+  const watchedConfirmPassword = watch('confirmPassword');
+
+  // 각 필드의 유효성 상태 확인
+  const getEmailCorrect = () => {
+    if (!dirtyFields.email || errors.email) return '';
+    if (z.string().email().safeParse(watchedEmail).success) {
+      return '사용 가능한 이메일입니다';
+    }
+    return '';
+  };
+
+  const getPasswordCorrect = () => {
+    if (!dirtyFields.password || errors.password) return '';
+    if (
+      z
+        .string()
+        .min(8)
+        .regex(/^(?=.*[A-Za-z])(?=.*\d)/)
+        .safeParse(watchedPassword).success
+    ) {
+      return '사용 가능한 비밀번호입니다';
+    }
+    return '';
+  };
+
+  const getConfirmPasswordCorrect = () => {
+    if (!dirtyFields.confirmPassword || errors.confirmPassword) return '';
+    if (watchedPassword === watchedConfirmPassword && watchedConfirmPassword) {
+      return '비밀번호가 일치합니다';
+    }
+    return '';
+  };
+
+  // 모든 필드가 입력되었는지 확인
+  const watchedValues = watch(['email', 'password', 'confirmPassword']);
+  const isAllFieldsFilled = watchedValues.every((value) => value);
+
+  // 버튼 활성화 조건: 모든 필드가 입력되고, 에러가 없으며, 폼이 유효한 상태
+  const isButtonEnabled =
+    isAllFieldsFilled && isValid && Object.keys(errors).length === 0;
+
+  const onSubmit = handleSubmit((data) => {
+    setLoginData(data);
+    router.push('/signup/profile');
+  });
+
+  const handleDuplicateCheck = async () => {
+    const isValid = await trigger('email');
+    if (!isValid) return;
+
+    // TODO: 중복 체크 API 호출
+    setIsDuplicate(true);
+  };
+
+  return (
+    <form
+      className="flex flex-col h-[calc(100vh-200px)] gap-6 mt-8"
+      onSubmit={onSubmit}
+    >
+      <div className="w-full flex items-center gap-2">
+        <div className="flex-1">
+          <BaseInput
+            id="email"
+            type="email"
+            label="이메일"
+            placeholder="이메일을 입력해주세요"
+            error={errors.email?.message}
+            correct={getEmailCorrect()}
+            {...register('email')}
+            helperText={
+              <div className="flex items-center gap-1">
+                <Info className="w-4 h-4" />
+                <span className="text-xs text-muted-foreground">
+                  이메일은 추후 변경이 불가합니다.
+                </span>
+              </div>
+            }
+          />
+        </div>
+        <Button
+          type="button"
+          onClick={handleDuplicateCheck}
+          className="w-[70px] h-[50px] self-start mt-8 text-xs"
+        >
+          중복 확인
+        </Button>
+      </div>
+
+      <BaseInput
+        id="password"
+        type={showPassword ? 'text' : 'password'}
+        label="비밀번호"
+        placeholder="비밀번호를 입력해주세요"
+        error={errors.password?.message}
+        correct={getPasswordCorrect()}
+        {...register('password')}
+        endIcon={
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="focus:outline-none"
+            tabIndex={-1}
+          >
+            {showPassword ? (
+              <Eye className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <EyeOff className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
+        }
+        helperText={
+          <div className="flex items-center gap-1">
+            <Info className="w-4 h-4" />
+            <span className="text-xs text-muted-foreground">
+              비밀번호는 영문+숫자 조합으로 8자 이상 입력해주세요.
+            </span>
+          </div>
+        }
+      />
+
+      <BaseInput
+        id="confirmPassword"
+        type={showConfirmPassword ? 'text' : 'password'}
+        label="비밀번호 확인"
+        placeholder="비밀번호를 다시 입력해주세요"
+        error={errors.confirmPassword?.message}
+        correct={getConfirmPasswordCorrect()}
+        {...register('confirmPassword')}
+        endIcon={
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="focus:outline-none"
+            tabIndex={-1}
+          >
+            {showConfirmPassword ? (
+              <EyeOff className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <Eye className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
+        }
+        helperText={
+          <div className="flex items-center gap-1">
+            <Info className="w-4 h-4" />
+            <span className="text-xs text-muted-foreground">
+              비밀번호를 다시 한번 입력해주세요.
+            </span>
+          </div>
+        }
+      />
+
+      <Button
+        type="submit"
+        className="mt-auto"
+        disabled={!isButtonEnabled && !isDuplicate}
+      >
+        이동
+      </Button>
+    </form>
+  );
+}

--- a/src/store/useSignUpStore.ts
+++ b/src/store/useSignUpStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { FormData } from '@/components/LoginForm';
+import { FormData } from '@/components/SignupForm';
 
 interface SignUpState {
   loginData: Partial<FormData>;


### PR DESCRIPTION
<img width="962" alt="스크린샷 2025-02-14 오후 3 01 21" src="https://github.com/user-attachments/assets/14fe75d3-7593-4e6a-a8e2-7a42c02e83f2" />

기존 이메일 로그인 UI 가 없어서 추가했고, 이메일 회원가입 페이지는 위 피그마대로 중복 확인 버튼을 추가한 수정했습니다.
UI 만 수정하였으며 기능적인 부분은 api가 만들어지면 작업 하도록 할게요.
