### PR TITLE
refactor: modal refactoring. GlobalModal로 재사용, hooks로 상태 분리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import '../styles/globals.css';
 import { Providers } from './providers';
 import { gmarketSans, OwnglyphPDH } from '@/styles/font';
 import { NavigationWrapper } from '@/components/common/Navigation/NavigationWrapper';
+import { GlobalModal } from '@/components/common/GlobalModal';
 
 export const metadata: Metadata = {
   title: '붕마카세',
@@ -22,6 +23,7 @@ export default function RootLayout({
         <Providers>
           <section className="w-full h-screen xs:w-[375px]">{children}</section>
           <NavigationWrapper />
+          <GlobalModal />
         </Providers>
       </body>
     </html>

--- a/src/components/common/GlobalModal/index.tsx
+++ b/src/components/common/GlobalModal/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useModalStore } from '@/hooks/useModalStore';
+import { Modal } from '@/components/ui/modal';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function GlobalModal() {
+  const { isOpen, content, closeModal } = useModalStore();
+
+  if (!content) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={closeModal}
+      titleElement={content.title}
+    >
+      <div className="flex flex-col items-center gap-6">
+        <p
+          className={cn(
+            'text-center text-lg',
+            content.type === 'error' ? 'text-destructive' : 'text-primary',
+          )}
+        >
+          {content.description}
+        </p>
+        <Button
+          className="w-full"
+          variant={content.type === 'error' ? 'secondary' : 'default'}
+          onClick={closeModal}
+        >
+          확인
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/hooks/useModalStore.ts
+++ b/src/hooks/useModalStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface ModalState {
+  isOpen: boolean;
+  content: {
+    title: string;
+    description: string;
+    type: 'success' | 'fail' | 'error';
+  } | null;
+  openModal: (content: ModalState['content']) => void;
+  closeModal: () => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isOpen: false,
+  content: null,
+  openModal: (content) => set({ isOpen: true, content }),
+  closeModal: () => set({ isOpen: false, content: null }),
+}));


### PR DESCRIPTION
기존 Modal은 특정 버튼이나 액션을 발생시켰을때 켜지는 모달이라면 

위 만든 모달은 비동기 통신 이후에 상태 값에 따라 모달의 내용이 바껴야 해서 따로 globalModal을 만들었습니다.

네이밍을 고민했지만, 저희 프로젝트 특성상 대부분 통신 이후에 모달을 띄워야 하는게 많아서 우선 GlobalModal로 지었습니다.

해당 모달을 이용한 코드는 앞서 만든 브랜치 feature/login에서 확인하시면 될 것 같아요

